### PR TITLE
Updated intellijidea community and ultimate to 2016.2

### DIFF
--- a/packages/intellijidea-community/intellijidea-community.nuspec
+++ b/packages/intellijidea-community/intellijidea-community.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>intellijidea-community</id>
     <title>JetBrains IntelliJ IDEA (Community Edition)</title>
-    <version>2016.1.1</version>
+    <version>2016.2</version>
     <authors>JetBrains</authors>
     <owners>Anthony Mastrean</owners>
     <summary>Capable and Ergonomic Java IDE</summary>
@@ -16,7 +16,7 @@
     <packageSourceUrl>https://github.com/AnthonyMastrean/chocolateypackages</packageSourceUrl>
     <releaseNotes>https://www.jetbrains.com/idea/whatsnew/</releaseNotes>
     <bugTrackerUrl>https://youtrack.jetbrains.com/issues/IDEA</bugTrackerUrl>
-    <docsUrl>https://www.jetbrains.com/help/idea/2016.1/meet-intellij-idea.html?origin=old_help</docsUrl>
+    <docsUrl>https://www.jetbrains.com/help/idea/2016.2/meet-intellij-idea.html?origin=old_help</docsUrl>
     <mailingListUrl>https://intellij-support.jetbrains.com/hc/en-us</mailingListUrl>
   </metadata>
 </package>

--- a/packages/intellijidea-community/tools/chocolateyInstall.ps1
+++ b/packages/intellijidea-community/tools/chocolateyInstall.ps1
@@ -2,5 +2,6 @@
   -PackageName 'intellijidea-community' `
   -FileType 'EXE' `
   -Silent '/S' `
-  -Checksum '33bcfb38a64a381a9586c1de1a5cb77f' `
-  -Url 'https://download.jetbrains.com/idea/ideaIC-2016.1.1.exe'
+  -Checksum 'baf058709d2f4bdf1fcddbedb8a7541c4a63200d7e800cb959de5a7ed1e53ee8' `
+  -ChecksumType 'sha256' `
+  -Url 'https://download.jetbrains.com/idea/ideaIC-2016.2.exe'

--- a/packages/intellijidea-community/tools/chocolateyUninstall.ps1
+++ b/packages/intellijidea-community/tools/chocolateyUninstall.ps1
@@ -6,4 +6,4 @@ Uninstall-ChocolateyPackage `
   -PackageName 'intellijidea-community' `
   -FileType 'EXE' `
   -Silent '/S' `
-  -File (Get-Uninstaller -Name 'IntelliJ IDEA Community Edition 2016.1.1')
+  -File (Get-Uninstaller -Name 'IntelliJ IDEA 2016.2')

--- a/packages/intellijidea-ultimate/intellijidea-ultimate.nuspec
+++ b/packages/intellijidea-ultimate/intellijidea-ultimate.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>intellijidea-ultimate</id>
     <title>JetBrains IntelliJ IDEA (Ultimate Edition)</title>
-    <version>2016.1.1</version>
+    <version>2016.2</version>
     <authors>JetBrains</authors>
     <owners>Anthony Mastrean</owners>
     <summary>Capable and Ergonomic Java IDE</summary>
@@ -16,7 +16,7 @@
     <packageSourceUrl>https://github.com/AnthonyMastrean/chocolateypackages</packageSourceUrl>
     <releaseNotes>https://www.jetbrains.com/idea/whatsnew/</releaseNotes>
     <bugTrackerUrl>https://youtrack.jetbrains.com/issues/IDEA</bugTrackerUrl>
-    <docsUrl>https://www.jetbrains.com/help/idea/2016.1/meet-intellij-idea.html?origin=old_help</docsUrl>
+    <docsUrl>https://www.jetbrains.com/help/idea/2016.2/meet-intellij-idea.html?origin=old_help</docsUrl>
     <mailingListUrl>https://intellij-support.jetbrains.com/hc/en-us</mailingListUrl>
   </metadata>
 </package>

--- a/packages/intellijidea-ultimate/tools/chocolateyInstall.ps1
+++ b/packages/intellijidea-ultimate/tools/chocolateyInstall.ps1
@@ -2,5 +2,6 @@
   -PackageName 'intellijidea-ultimate' `
   -FileType 'EXE' `
   -Silent '/S' `
-  -Checksum '0a1357351b004c31686270ffff8a0351' `
-  -Url 'https://download.jetbrains.com/idea/ideaIU-2016.1.1.exe'
+  -Checksum '0f0878d6ff18ec62dfdd15ce53dc7fbd7a80340b0ceab315d5330787e4df041e' `
+  -ChecksumType 'sha256' `
+  -Url 'https://download.jetbrains.com/idea/ideaIU-2016.2.exe'

--- a/packages/intellijidea-ultimate/tools/chocolateyUninstall.ps1
+++ b/packages/intellijidea-ultimate/tools/chocolateyUninstall.ps1
@@ -6,4 +6,4 @@ Uninstall-ChocolateyPackage `
   -PackageName 'intellijidea-ultimate' `
   -FileType 'EXE' `
   -Silent '/S' `
-  -File (Get-Uninstaller -Name 'IntelliJ IDEA Ultimate Edition 2016.1.1')
+  -File (Get-Uninstaller -Name 'IntelliJ IDEA 2016.2')


### PR DESCRIPTION
Changed the sources to refer to version 2016.2.
Changed ChecksumType on packages to sha256
Added checksums from jetbrains website (links below)
Fixed package name in uninstall script.

https://download.jetbrains.com/idea/ideaIC-2016.2.exe.sha256
https://download.jetbrains.com/idea/ideaIU-2016.2.exe.sha256

I have tested the install / uninstall loop for Ultimate.  It installed and uninstalled clean for Ultimate.  I have not done so for the Community edition.