### PR TITLE
Update IntelliJIDEA to 2016.3.3

### DIFF
--- a/packages/intellijidea-community/intellijidea-community.nuspec
+++ b/packages/intellijidea-community/intellijidea-community.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>intellijidea-community</id>
     <title>JetBrains IntelliJ IDEA (Community Edition)</title>
-    <version>2016.3.2</version>
+    <version>2016.3.3</version>
     <authors>JetBrains</authors>
     <owners>Anthony Mastrean</owners>
     <summary>Capable and Ergonomic Java IDE</summary>

--- a/packages/intellijidea-community/tools/chocolateyInstall.ps1
+++ b/packages/intellijidea-community/tools/chocolateyInstall.ps1
@@ -2,8 +2,8 @@
 
 $packageName = 'intellijidea-community'
 $toolsDir    = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$url         = 'https://download.jetbrains.com/idea/ideaIC-2016.3.2.exe'
-$url64       = 'https://download.jetbrains.com/idea/ideaIC-2016.3.2.exe'
+$url         = 'https://download.jetbrains.com/idea/ideaIC-2016.3.3.exe'
+$url64       = 'https://download.jetbrains.com/idea/ideaIC-2016.3.3.exe'
 
 $packageArgs = @{
   packageName    = $packageName
@@ -14,9 +14,9 @@ $packageArgs = @{
 
   softwareName   = 'IntelliJ IDEA Community Edition 2016.3*'
 
-  checksum       = 'B40C1182C998439FC2A47CA79E3D703C83007353DBBFE8925B303E59ED88A437'
+  checksum       = '74B3C292A93DBA703B6C37D8C368AA35D51DECEE3CB57292962691F0ACCBB13D'
   checksumType   = 'sha256'
-  checksum64     = 'B40C1182C998439FC2A47CA79E3D703C83007353DBBFE8925B303E59ED88A437'
+  checksum64     = '74B3C292A93DBA703B6C37D8C368AA35D51DECEE3CB57292962691F0ACCBB13D'
   checksumType64 = 'sha256'
 
   silentArgs     = '/S'

--- a/packages/intellijidea-ultimate/intellijidea-ultimate.nuspec
+++ b/packages/intellijidea-ultimate/intellijidea-ultimate.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>intellijidea-ultimate</id>
     <title>JetBrains IntelliJ IDEA (Ultimate Edition)</title>
-    <version>2016.3.2</version>
+    <version>2016.3.3</version>
     <authors>JetBrains</authors>
     <owners>Anthony Mastrean</owners>
     <summary>Capable and Ergonomic Java IDE</summary>

--- a/packages/intellijidea-ultimate/tools/chocolateyInstall.ps1
+++ b/packages/intellijidea-ultimate/tools/chocolateyInstall.ps1
@@ -2,8 +2,8 @@
 
 $packageName = 'intellijidea-ultimate'
 $toolsDir    = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$url         = 'https://download.jetbrains.com/idea/ideaIU-2016.3.2.exe'
-$url64       = 'https://download.jetbrains.com/idea/ideaIU-2016.3.2.exe'
+$url         = 'https://download.jetbrains.com/idea/ideaIU-2016.3.3.exe'
+$url64       = 'https://download.jetbrains.com/idea/ideaIU-2016.3.3.exe'
 
 $packageArgs = @{
   packageName    = $packageName
@@ -14,9 +14,9 @@ $packageArgs = @{
 
   softwareName   = 'IntelliJ IDEA 2016.3*'
 
-  checksum       = '7498D17DA49B71C6CF40F99288F5383DDC918BB79F4539D7E900507AAFE89F1A'
+  checksum       = 'F2B860EF5618EA11A1510AC64D9EEACF8D3D3627C34B00D43682A5BEF0E12B75'
   checksumType   = 'sha256'
-  checksum64     = '7498D17DA49B71C6CF40F99288F5383DDC918BB79F4539D7E900507AAFE89F1A'
+  checksum64     = 'F2B860EF5618EA11A1510AC64D9EEACF8D3D3627C34B00D43682A5BEF0E12B75'
   checksumType64 = 'sha256'
 
   silentArgs     = '/S'


### PR DESCRIPTION
Updated to version 2016.3.3.
Chocolatey hasn't released version 0.10.4 so I haven't removed the workaround for the uninstall script bug.