### PR TITLE
Use k-takata's Windows build of ag and update package information

### DIFF
--- a/packages/ag/ag.nuspec
+++ b/packages/ag/ag.nuspec
@@ -4,11 +4,12 @@
     <id>ag</id>
     <title>The Silver Searcher</title>
     <version>2.1.0.1</version>
-    <authors>K. Takata, Geoff Greer</authors>
+    <authors>Geoff Greer, K. Takata</authors>
     <owners>Anthony Mastrean</owners>
     <summary>The Silver Searcher is like grep or ack, except faster.</summary>
     <description>The Silver Searcher is like grep or ack, except faster. It's written in super-optimized C (like grep) and it's intelligent about entirely skipping files that you don't want to waste time searching (like ack).</description>
-    <projectUrl>https://github.com/k-takata/the_silver_searcher-win32</projectUrl>
+    <projectUrl>https://geoff.greer.fm/ag/</projectUrl>
+    <projectSourceUrl>https://github.com/k-takata/the_silver_searcher-win32</projectSourceUrl>
     <tags>ag ack foss grep search</tags>
     <licenseUrl>https://github.com/k-takata/the_silver_searcher-win32/blob/master/LICENSE</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/packages/ag/ag.nuspec
+++ b/packages/ag/ag.nuspec
@@ -3,14 +3,15 @@
   <metadata>
     <id>ag</id>
     <title>The Silver Searcher</title>
-    <version>0.29.1.1641</version>
-    <authors>Krzysztof Kowalczyk, Geoff Greer</authors>
+    <version>2.1.0.1</version>
+    <authors>K. Takata, Geoff Greer</authors>
     <owners>Anthony Mastrean</owners>
     <summary>The Silver Searcher is like grep or ack, except faster.</summary>
     <description>The Silver Searcher is like grep or ack, except faster. It's written in super-optimized C (like grep) and it's intelligent about entirely skipping files that you don't want to waste time searching (like ack).</description>
-    <projectUrl>http://blog.kowalczyk.info/software/the-silver-searcher-for-windows.html</projectUrl>
-    <tags>ag ack search grep</tags>
-    <licenseUrl>https://github.com/kjk/the_silver_searcher/blob/76544feebd8020c841b76b3c6ec62799997024e0/LICENSE</licenseUrl>
+    <projectUrl>https://github.com/k-takata/the_silver_searcher-win32</projectUrl>
+    <tags>ag ack foss grep search</tags>
+    <licenseUrl>https://github.com/k-takata/the_silver_searcher-win32/blob/master/LICENSE</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <packageSourceUrl>https://github.com/AnthonyMastrean/chocolateypackages/tree/master/packages/ag</packageSourceUrl>
   </metadata>
 </package>

--- a/packages/ag/tools/chocolateyInstall.ps1
+++ b/packages/ag/tools/chocolateyInstall.ps1
@@ -1,7 +1,14 @@
-﻿$id  = "ag"
-$url = "https://kjkpub.s3.amazonaws.com/software/the_silver_searcher/rel/0.29.1-1641/ag.zip"
+﻿$id    = "ag"
+$url   = "https://github.com/k-takata/the_silver_searcher-win32/releases/download/2017-08-31%2F2.1.0-1/ag-2017-08-31_2.1.0-1-x86.zip"
+$url64 = "https://github.com/k-takata/the_silver_searcher-win32/releases/download/2017-08-31%2F2.1.0-1/ag-2017-08-31_2.1.0-1-x64.zip"
 
-$tools   = Split-Path $MyInvocation.MyCommand.Definition
-$content = Join-Path (Split-Path $tools) "content"
+$toolsPath  = Split-Path $MyInvocation.MyCommand.Definition
 
-Install-ChocolateyZipPackage -PackageName $id -Url $url -UnzipLocation $content
+$packageArgs = @{
+    packageName   = $id
+    url           = $url
+    url64         = $url64
+    unzipLocation = $toolsPath
+}
+
+Install-ChocolateyZipPackage @packageArgs

--- a/packages/ag/tools/chocolateyInstall.ps1
+++ b/packages/ag/tools/chocolateyInstall.ps1
@@ -1,14 +1,20 @@
-﻿$id    = "ag"
-$url   = "https://github.com/k-takata/the_silver_searcher-win32/releases/download/2017-08-31%2F2.1.0-1/ag-2017-08-31_2.1.0-1-x86.zip"
-$url64 = "https://github.com/k-takata/the_silver_searcher-win32/releases/download/2017-08-31%2F2.1.0-1/ag-2017-08-31_2.1.0-1-x64.zip"
+﻿$url        = 'https://github.com/k-takata/the_silver_searcher-win32/releases/download/2017-08-31%2F2.1.0-1/ag-2017-08-31_2.1.0-1-x86.zip'
+$checksum   = '28456A424A30B12BE3BE2B9D427BC67031BC436F87F1100607CFA9A44C1AF95D'
+$url64      = 'https://github.com/k-takata/the_silver_searcher-win32/releases/download/2017-08-31%2F2.1.0-1/ag-2017-08-31_2.1.0-1-x64.zip'
+$checksum64 = '2F0B83E705D6224DF82BE92014726875BEC925C6B56EF84170D1F19EDDFAA439'
 
-$toolsPath  = Split-Path $MyInvocation.MyCommand.Definition
+$id                    = 'ag'
+$checksumType          = 'sha256'
+$checksumType64        = 'sha256'
+$ErrorActionPreference = 'Stop';
+$toolsDir              = Split-Path $MyInvocation.MyCommand.Definition
 
-$packageArgs = @{
-    packageName   = $id
-    url           = $url
-    url64         = $url64
-    unzipLocation = $toolsPath
-}
-
-Install-ChocolateyZipPackage @packageArgs
+Install-ChocolateyZipPackage `
+    -PackageName $id `
+    -UnzipLocation $toolsDir `
+    -Url $url `
+    -Url64 $url64 `
+    -Checksum $checksum `
+    -ChecksumType $checksumType `
+    -Checksum64 $checksum64 `
+    -ChecksumType64 $checksumType64 `

--- a/packages/ag/tools/chocolateyInstall.ps1
+++ b/packages/ag/tools/chocolateyInstall.ps1
@@ -1,20 +1,15 @@
-﻿$url        = 'https://github.com/k-takata/the_silver_searcher-win32/releases/download/2017-08-31%2F2.1.0-1/ag-2017-08-31_2.1.0-1-x86.zip'
-$checksum   = '28456A424A30B12BE3BE2B9D427BC67031BC436F87F1100607CFA9A44C1AF95D'
-$url64      = 'https://github.com/k-takata/the_silver_searcher-win32/releases/download/2017-08-31%2F2.1.0-1/ag-2017-08-31_2.1.0-1-x64.zip'
-$checksum64 = '2F0B83E705D6224DF82BE92014726875BEC925C6B56EF84170D1F19EDDFAA439'
+﻿$ErrorActionPreference = 'Stop';
+$toolsDir = Split-Path $MyInvocation.MyCommand.Definition
 
-$id                    = 'ag'
-$checksumType          = 'sha256'
-$checksumType64        = 'sha256'
-$ErrorActionPreference = 'Stop';
-$toolsDir              = Split-Path $MyInvocation.MyCommand.Definition
+$packageArgs = @{
+  packageName    = 'ag'
+  url            = 'https://github.com/k-takata/the_silver_searcher-win32/releases/download/2017-08-31%2F2.1.0-1/ag-2017-08-31_2.1.0-1-x86.zip'
+  checksum       = '28456A424A30B12BE3BE2B9D427BC67031BC436F87F1100607CFA9A44C1AF95D'
+  url64          = 'https://github.com/k-takata/the_silver_searcher-win32/releases/download/2017-08-31%2F2.1.0-1/ag-2017-08-31_2.1.0-1-x64.zip'
+  checksum64     = '2F0B83E705D6224DF82BE92014726875BEC925C6B56EF84170D1F19EDDFAA439'
+  checksumType   = 'sha256'
+  checksumType64 = 'sha256'
+  unzipLocation  = $toolsDir
+}
 
-Install-ChocolateyZipPackage `
-    -PackageName $id `
-    -UnzipLocation $toolsDir `
-    -Url $url `
-    -Url64 $url64 `
-    -Checksum $checksum `
-    -ChecksumType $checksumType `
-    -Checksum64 $checksum64 `
-    -ChecksumType64 $checksumType64 `
+Install-ChocolateyZipPackage @packageArgs


### PR DESCRIPTION
Solves #250. Switch from Krzysztof Kowalczyk's to k-takata's up-to-date
builds.

Other changes

- Add `foss` tag to ag.nuspec
- Add packageSourceUrl to ag.nuspec
- Format arguments as a hashtable and pass that to
  `Install-ChocolateyZipPackage`.