### PR TITLE
Mouse without Borders - 2.1.8.0105

### DIFF
--- a/packages/mousewithoutborders/mousewithoutborders.nuspec
+++ b/packages/mousewithoutborders/mousewithoutborders.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>mousewithoutborders</id>
-    <version>2.1.6.1027</version>
+    <version>2.1.8.0105</version>
     <title>Mouse Without Borders</title>
     <authors>Microsoft Garage,Truong Do</authors>
     <owners>Anthony Mastrean</owners>
@@ -13,7 +13,7 @@
     <bugTrackerUrl>http://aka.ms/mm</bugTrackerUrl>
     <packageSourceUrl>https://github.com/AnthonyMastrean/chocolateypackages/</packageSourceUrl>
     <releaseNotes>
-New in this release: Works better with Windows 8.1 and Windows 10.
+New in this release: Bug fixes and improvements.
     </releaseNotes>
     <summary>Mouse without Borders is a project that allows you to reach across your PCs as if they were part of one single desktop.</summary>
     <description>

--- a/packages/mousewithoutborders/tools/chocolateyInstall.ps1
+++ b/packages/mousewithoutborders/tools/chocolateyInstall.ps1
@@ -1,7 +1,7 @@
 ﻿Install-ChocolateyPackage `
   -PackageName 'mousewithoutborders' `
   -Url 'https://download.microsoft.com/download/6/5/8/658AFC4C-DC02-4CB8-839D-10253E89FFF7/MouseWithoutBordersSetup.msi' `
-  -Checksum '53626A4793BF679B492FD9E16F1337D07B0D95121C4D82A553D320C56DF54FE3' `
+  -Checksum 'c73d373275519de5545824ff20e886e4c2d76770cb77f8b685c0b52a1c07e97d' `
   -ChecksumType 'SHA256' `
   -FileType 'MSI' `
   -SilentArgs '/QN'


### PR DESCRIPTION
Updated version, release notes, and checksum.

FYI. Chocolatey upgrade fails with MSI error 1638, "Another version of this program is already installed". Had to manually uninstall before installing new version. Possible resolution could be to check for existing installation first and performing an uninstall before attempting installation, however uninstall wipes settings.