### PR TITLE
Updated CheatEngine 6.8.1 -> 6.8.2

### DIFF
--- a/packages/cheatengine/cheatengine.nuspec
+++ b/packages/cheatengine/cheatengine.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>cheatengine</id>
     <title>Cheat Engine</title>
-    <version>6.8.1</version>
+    <version>6.8.2</version>
     <authors>Dark Byte</authors>
     <owners>Anthony Mastrean</owners>
     <summary>Cheat Engine is an open source tool designed to help you modify single player games.</summary>

--- a/packages/cheatengine/tools/chocolateyInstall.ps1
+++ b/packages/cheatengine/tools/chocolateyInstall.ps1
@@ -1,7 +1,9 @@
-﻿Install-ChocolateyPackage `
+﻿$version_without_dots = $env:ChocolateyPackageVersion -replace '[.]'
+
+Install-ChocolateyPackage `
   -PackageName 'cheatengine' `
-  -Url 'https://github.com/cheat-engine/cheat-engine/releases/download/v6.8.1/CheatEngine681.exe' `
-  -Checksum '6F795F11FA3983B4779426DD6DCE8346E279B099F62AD4BAB5D246B932E09885' `
+  -Url "https://github.com/cheat-engine/cheat-engine/releases/download/$($env:ChocolateyPackageVersion)/CheatEngine$($version_without_dots).exe" `
+  -Checksum '61a35039e8da357e9d6f06642f417dc897ed9a077f6a99e84b46ada1a211d949' `
   -ChecksumType 'SHA256' `
   -FileType 'EXE' `
   -Silent '/VERYSILENT /NORESTART /NOCANDY'

--- a/packages/cheatengine/tools/chocolateyUninstall.ps1
+++ b/packages/cheatengine/tools/chocolateyUninstall.ps1
@@ -2,4 +2,4 @@
   -PackageName 'cheatengine' `
   -FileType 'EXE' `
   -Silent '/VERYSILENT /NORESTART' `
-  -File (Get-UninstallRegistryKey -SoftwareName 'Cheat Engine 6.8.1').UninstallString.Trim('"')
+  -File (Get-UninstallRegistryKey -SoftwareName "Cheat Engine $env:ChocolateyPackageVersion").UninstallString.Trim('"')


### PR DESCRIPTION
I found a way to dynamically get the version with and without the dots using the [choco environment variables](https://github.com/chocolatey/choco/wiki/HelpersReference#environment-variables).

Removed the v prefix in the auto-update key because it only works with `v6.8.1`. See https://github.com/cheat-engine/cheat-engine/issues/477

I also tested the package locally to make sure it installs and uninstalls correctly 😄 