### PR TITLE
[parsec] Added AutoHotkey dependency and scripts to "silence" the installation process

### DIFF
--- a/packages/parsec/parsec.nuspec
+++ b/packages/parsec/parsec.nuspec
@@ -24,6 +24,9 @@ We strive to build the best game streaming technology on the market. In our ques
     <docsUrl>https://support.parsecgaming.com/hc/en-us</docsUrl>
     <mailingListUrl>https://support.parsecgaming.com/hc/en-us</mailingListUrl>
     <bugTrackerUrl>https://support.parsecgaming.com/hc/en-us</bugTrackerUrl>
-    <iconUrl>https://cdn.rawgit.com/AnthonyMastrean/chocolateypackages/master/public/icons/parsec.png</iconUrl>
+    <iconUrl>https://cdn.rawgit.com/AnthonyMastrean/chocolateypackages/master/public/icons/parsec.png</iconUrl>    
+    <dependencies>
+      <dependency id="autohotkey.portable" version="1.1.30.01" />
+    </dependencies>
   </metadata>
 </package>

--- a/packages/parsec/tools/chocolateyInstall.ps1
+++ b/packages/parsec/tools/chocolateyInstall.ps1
@@ -1,10 +1,28 @@
-﻿Install-ChocolateyPackage `
-    -PackageName 'parsec' `
-    -Url 'https://s3.amazonaws.com/parsec-build/package/parsec-windows32.exe' `
-    -Checksum '1EF14507AF49B87C01C740905B3E7F0FC08170C92E06DB5A6A5AF3B3F0496585' `
-    -ChecksumType 'SHA256' `
-    -Url64 'https://s3.amazonaws.com/parsec-build/package/parsec-windows.exe' `
-    -Checksum64 '405A79D5827969A6ADF284D6C229E3E27C8BB1E0FD8F3C12F1DFED4029DD49F4' `
-    -ChecksumType64 'SHA256' `
-    -FileType 'EXE' `
-    -SilentArgs ''
+﻿$ErrorActionPreference = 'Stop';
+
+if ($PSVersionTable.BuildVersion -lt 6.1) { throw 'Windows 7 and newer required.'}
+
+$toolsDir = "$(Split-Path -Parent $MyInvocation.MyCommand.Definition)"
+$url = 'https://s3.amazonaws.com/parsec-build/package/parsec-windows32.exe'
+$url64 = 'https://s3.amazonaws.com/parsec-build/package/parsec-windows.exe'
+
+$packageArgs = @{
+    packageName    = $env:ChocolateyPackageName
+    unzipLocation  = $toolsDir
+    fileType       = 'EXE'
+    url            = $url
+    url64bit       = $url64
+    softwareName   = 'parsec*'
+    checksum       = '1ef14507af49b87c01c740905b3e7f0fc08170c92e06db5a6a5af3b3f0496585'
+    checksumType   = 'sha256'
+    checksum64     = '405a79d5827969a6adf284d6c229e3e27c8bb1e0fd8f3c12f1dfed4029dd49f4'
+    checksumType64 = 'sha256'
+    silentArgs     = ""
+    validExitCodes = @(0)
+}
+
+$ahkExe = 'AutoHotKey'
+$ahkFile = Join-Path $toolsDir "installParsec.ahk"
+$null = Start-Process -FilePath $ahkExe -ArgumentList $ahkFile -PassThru
+ 
+Install-ChocolateyPackage @packageArgs

--- a/packages/parsec/tools/chocolateyUninstall.ps1
+++ b/packages/parsec/tools/chocolateyUninstall.ps1
@@ -1,5 +1,13 @@
-Uninstall-ChocolateyPackage `
-  -PackageName 'parsec' `
-  -FileType 'EXE' `
-  -Silent '' `
-  -File (Get-UninstallRegistryKey -SoftwareName 'Parsec').UninstallString
+$toolsDir = "$(Split-Path -Parent $MyInvocation.MyCommand.Definition)"
+$ahkExe = 'AutoHotKey'
+$ahkFile = Join-Path $toolsDir "removeParsec.ahk"
+
+$null = Start-Process -FilePath $ahkExe -ArgumentList $ahkFile
+
+# Using Start-Process -Wait since Uninstall-ChocolateyPackage exits immediately
+$uninstall = Start-Process -FilePath (Get-UninstallRegistryKey -SoftwareName 'Parsec').UninstallString -NoNewWindow -Wait -PassThru
+
+if ($uninstall.ExitCode -notin 0,3010)
+{
+    throw "Removal of parsec was NOT successful. Exit code of process was $($uninstall.ExitCode)"
+}

--- a/packages/parsec/tools/installParsec.ahk
+++ b/packages/parsec/tools/installParsec.ahk
@@ -1,0 +1,13 @@
+#NoEnv
+#NoTrayIcon
+SendMode Input
+SetWorkingDir %A_ScriptDir%
+SetTitleMatchMode, 1
+SetControlDelay -1
+ 
+winTitleInstall = Parsec Setup
+WinWait, %winTitleInstall%, Installing
+WinMinimize, %winTitleInstall%, Installing
+
+WinWait, %winTitleInstall%, controller , 300
+ControlClick , Button2, %winTitleInstall%, controller

--- a/packages/parsec/tools/installParsec.ahk
+++ b/packages/parsec/tools/installParsec.ahk
@@ -7,7 +7,8 @@ SetControlDelay -1
  
 winTitleInstall = Parsec Setup
 WinWait, %winTitleInstall%, Installing
-WinMinimize, %winTitleInstall%, Installing
+WinHide, %winTitleInstall%, Installing
 
 WinWait, %winTitleInstall%, controller , 300
 ControlClick , Button2, %winTitleInstall%, controller
+WinHide, %winTitleInstall%, Installing

--- a/packages/parsec/tools/removeParsec.ahk
+++ b/packages/parsec/tools/removeParsec.ahk
@@ -1,0 +1,15 @@
+#NoEnv
+#NoTrayIcon
+SendMode Input
+SetWorkingDir %A_ScriptDir%
+SetTitleMatchMode, 1
+SetControlDelay -1
+ 
+winTitleUninstall = Parsec Uninstall
+
+WinWait, %winTitleUninstall%, Remove , 300
+WinMinimize, %winTitleUninstall%, Remove
+ControlClick , Button2, %winTitleUninstall%, Remove
+
+WinWait, %winTitleUninstall%, Complete , 300
+ControlClick , Button2, %winTitleUninstall%, Complete


### PR DESCRIPTION
Dependency to AutoHotkey.Portable added to auto-click the installer. The installer is hidden immediately, hiding the removal window unfortunately did not work, so it is only minimized. The removal process is pretty quick and it is not really noticeable.

Tested the package installation/removal with Windows 10 a couple of times.