### PR TITLE
Update to depend on OpenJDK rather than Oracle JDK

### DIFF
--- a/packages/ghidra/ghidra.nuspec
+++ b/packages/ghidra/ghidra.nuspec
@@ -24,7 +24,7 @@ In support of NSA's Cybersecurity mission, Ghidra was built to solve scaling and
 This repository is a placeholder for the full open source release. Be assured efforts are under way to make the software available here. In the meantime, enjoy using Ghidra on your SRE efforts, developing your own scripts and plugins, and perusing the over-one-million-lines of Java and Sleigh code released within the initial public release. The release can be downloaded from our project homepage. Please consider taking a look at our contributor guide to see how you can participate in this open source project when it becomes available.
     </description>
     <dependencies>
-      <dependency id="jdk11" version="11.0" />
+      <dependency id="openjdk" version="11.0" />
     </dependencies>
   </metadata>
 </package>


### PR DESCRIPTION
OpenJDK is recommended for Ghidra by NSA, and due to Oracle's license changes, it just makes more sense to follow those recommendations.