### PR TITLE
Update Kindle to latest; revise project URLs

### DIFF
--- a/packages/kindle/kindle.nuspec
+++ b/packages/kindle/kindle.nuspec
@@ -10,14 +10,14 @@
     <description>
 The Kindle app is available for most major smartphones, tablets and computers. That means with our free Kindle reading apps, you can buy a Kindle book once, and read it on any device with the Kindle app installed*. You can also read that same Kindle book on a Kindle device if you own one.
     </description>
-    <projectUrl>https://www.amazon.com/gp/digital/fiona/kcp-landing-page</projectUrl>
-    <releaseNotes>https://www.amazon.com/gp/digital/fiona/kcp-landing-page</releaseNotes>
-    <docsUrl>https://www.amazon.com/gp/digital/fiona/kcp-landing-page</docsUrl>
-    <bugTrackerUrl>https://www.amazon.com/gp/help/customer/display.html/ref=hp_ss_v3_ds_t4?ie=UTF8&amp;nodeId=200127470</bugTrackerUrl>
-    <mailingListUrl>https://www.amazon.com/gp/help/customer/forums/kindleqna/ref=hp_ss_qs_v3_dv_kh</mailingListUrl>
+    <projectUrl>https://www.amazon.com/kindle-dbs/fd/kcp</projectUrl>
+    <releaseNotes>https://www.amazon.com/kindle-dbs/fd/kcp</releaseNotes>
+    <docsUrl>https://www.amazon.com/gp/help/customer/display.html?nodeId=G3YXTENMKSKMKG43</docsUrl>
+    <bugTrackerUrl>https://www.amazonforum.com/forums/digital-content/kindle-books?filter-prefix=194</bugTrackerUrl>
+    <mailingListUrl>https://www.amazonforum.com/new-content?filter-prefix=194&filter-thread-search=&filter-date-range-type=1&filter-association-type=1</mailingListUrl>
     <packageSourceUrl>https://github.com/AnthonyMastrean/chocolateypackages</packageSourceUrl>
     <tags>admin amazon kindle</tags>
-    <licenseUrl>http://www.amazon.com/gp/help/customer/display.html/ref=hp_pcland_recterms?nodeId=200506200</licenseUrl>
+    <licenseUrl>https://www.amazon.com/gp/help/customer/display.html?nodeId=200499360</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <iconUrl>https://raw.githubusercontent.com/AnthonyMastrean/chocolateypackages/master/public/icons/kindle.png</iconUrl>
     <dependencies>

--- a/packages/kindle/tools/chocolateyInstall.ps1
+++ b/packages/kindle/tools/chocolateyInstall.ps1
@@ -2,6 +2,6 @@
   -PackageName 'kindle' `
   -InstallerType 'EXE' `
   -SilentArgs '/S' `
-  -Url 'https://s3.amazonaws.com/kindleforpc/52064/KindleForPC-installer-1.25.52064.exe' `
-  -Checksum '314678A0A3B867BF412936ADAA67C6AB6D41C961F359A46F99C3AFA591702EF7' `
+  -Url 'https://s3.amazonaws.com/kindleforpc/55076/KindleForPC-installer-1.26.55076.exe' `
+  -Checksum 'c9d104c4aad027a89ab92a521b7d64bdee422136cf562f8879f0af96abd74511' `
   -ChecksumType 'SHA256'


### PR DESCRIPTION
Updated the install script to point to latest released Kindle version (1.26.55076) and new checksum.  Revised Kindle software project URLs to point to more direct resources on Amazon's site.