### PR TITLE
Use non-IA source for rsync package

### DIFF
--- a/packages/rsync/tools/chocolateyInstall.ps1
+++ b/packages/rsync/tools/chocolateyInstall.ps1
@@ -4,7 +4,7 @@ $content = Join-Path $package 'cwrsync_5.5.0_x86_free'
 
 Install-ChocolateyZipPackage `
     -PackageName 'rsync' `
-    -Url 'https://web.archive.org/web/20160613105413/https://www.itefix.net/dl/cwRsync_5.5.0_x86_Free.zip' `
+    -Url 'https://itefix.net/dl/free-software/cwrsync_5.5.0_x86_free.zip' `
     -Checksum '37E8EF21AC975D4EE86C9D3BE40C8935E8B9D0BA84E9302FC106B9452296CB85' `
     -ChecksumType 'SHA256' `
     -UnzipLocation $package


### PR DESCRIPTION
This PR changes the source url for the rsync package to an updated
link on the original site rather than an Internet Archive snapshot.

Source: https://www.itefix.net/cwrsync?qt-cwrsync=7#qt-cwrsync