### PR TITLE
Update Apache Ant to version 1.10.8

### DIFF
--- a/packages/ant/ant.nuspec
+++ b/packages/ant/ant.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>ant</id>
     <title>Apache Ant</title>
-    <version>1.10.5</version>
+    <version>1.10.8</version>
     <authors>Apache</authors>
     <owners>Anthony Mastrean</owners>
     <summary>Apache Ant is a Java library and command-line tool whose mission is to drive processes described in build files as targets and extension points dependent upon each other.</summary>
@@ -21,8 +21,5 @@ Apache Ant is a Java library and command-line tool whose mission is to drive pro
     <mailingListUrl>https://ant.apache.org/mail.html</mailingListUrl>
     <packageSourceUrl>https://github.com/AnthonyMastrean/chocolateypackages/</packageSourceUrl>
     <projectSourceUrl>https://ant.apache.org/git.html</projectSourceUrl>
-    <dependencies>
-        <dependency id="jre8" version="[8.0,)" />
-    </dependencies>
   </metadata>
 </package>

--- a/packages/ant/tools/chocolateyInstall.ps1
+++ b/packages/ant/tools/chocolateyInstall.ps1
@@ -5,8 +5,8 @@ $ant_bat = Join-Path $ant_home 'bin/ant.bat'
 
 Install-ChocolateyZipPackage `
     -PackageName 'ant' `
-    -Url 'https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.5-bin.zip' `
-    -Checksum '2E48F9E429D67708F5690BC307232F08440D01EBE414059292B6543971DA9C7CD259C21533B9163B4DD753321C17BD917ADF8407D03245A0945FC30A4E633163' `
+    -Url 'https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.8-bin.zip' `
+    -Checksum '24A49F9EFD19D1202700192BA811E4A0A714B2E16A37CA8124309DDEC6754A22FA12C7E5A07D35A41A104C6B6BB514D5C99A2438B758E5B6C75CC583A2B2385F' `
     -ChecksumType 'SHA512' `
     -UnzipLocation $package
 

--- a/packages/ant/tools/chocolateyUninstall.ps1
+++ b/packages/ant/tools/chocolateyUninstall.ps1
@@ -1,6 +1,6 @@
 ﻿$tools = Split-Path $MyInvocation.MyCommand.Definition
 $package = Split-Path $tools
-$ant_home = Join-Path $package 'apache-ant-1.10.5'
+$ant_home = Join-Path $package 'apache-ant-1.10.8'
 $ant_bat = Join-Path $ant_home 'bin/ant.bat'
 
 Uninstall-BinFile -Name 'ant' -Path $ant_bat


### PR DESCRIPTION
Hello @AnthonyMastrean, @ZeddG93 and @jordigg 
I update Apache Ant to version 1.10.8, please merge when you have time.

I have also removed dependency on `jre8`, it is in general a bad practice for a Java application to depend on a specific version JDK or JRE as most programmers already have those installed and their `JAVA_HOME` defined. Nowadays people use different versions of Java versions (6, 8, 11, 14 and etc) or distributions (Oracle, J9, tons of OpenJDK distributions) depending on their work environments, so it is generally not desirable to be forced to use Oracle JRE 8.
For example, Gradle and Maven packages on Chocolatey did not depend on any JDK or JRE, programmers are free to install their own, from Chocolatey or not.

Thank you for your time!