### PR TITLE
chore(bind‑toolsonly): Upgrade to v9.16.8

### DIFF
--- a/packages/bind-toolsonly/bind-toolsonly.nuspec
+++ b/packages/bind-toolsonly/bind-toolsonly.nuspec
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<package xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+<!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. -->
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>bind-toolsonly</id>
     <title>BIND Tools</title>
-    <version>9.14.2</version>
+    <version>9.16.8</version>
     <authors>ISC</authors>
     <owners>Anthony Mastrean</owners>
     <summary>The most widely used Name Server Software.</summary>
@@ -12,9 +13,9 @@ BIND is open source software that implements the Domain Name System (DNS) protoc
 
 BIND is by far the most widely used DNS software on the Internet, providing a robust and stable platform on top of which organizations can build distributed computing systems with the knowledge that those systems are fully compliant with published DNS standards.
     </description>
-    <projectUrl>http://www.isc.org/software/bind</projectUrl>
-    <releaseNotes>http://ftp.isc.org/isc/bind9/9.14.2/RELEASE-NOTES-bind-9.14.2.html</releaseNotes>
-    <docsUrl>http://ftp.isc.org/isc/bind9/9.14.2/doc/arm/Bv9ARM.pdf</docsUrl>
+    <projectUrl>https://www.isc.org/bind</projectUrl>
+    <releaseNotes>https://downloads.isc.org/isc/bind9/9.16.8/RELEASE-NOTES-bind-9.16.8.html</releaseNotes>
+    <docsUrl>https://downloads.isc.org/isc/bind9/9.16.8/doc/arm/html/</docsUrl>
     <packageSourceUrl>https://github.com/AnthonyMastrean/chocolateypackages/</packageSourceUrl>
     <bugTrackerUrl>https://www.isc.org/community/report-bug/</bugTrackerUrl>
     <mailingListUrl>https://www.isc.org/community/mailing-list/</mailingListUrl>

--- a/packages/bind-toolsonly/tools/chocolateyInstall.ps1
+++ b/packages/bind-toolsonly/tools/chocolateyInstall.ps1
@@ -1,5 +1,19 @@
-﻿$tools = Split-Path -Path $MyInvocation.MyCommand.Definition
-$content = Join-Path -Path (Split-Path -Path $tools) -ChildPath 'content'
+﻿$ErrorActionPreference = 'Stop'
+
+$toolsDir = Split-Path -Path $MyInvocation.MyCommand.Definition
+$contentDir = Join-Path -Path (Split-Path -Path $toolsDir) -ChildPath 'content'
+
+$url64      = 'https://downloads.isc.org/isc/bind9/9.16.8/BIND9.16.8.x64.zip'
+$checksum64 = '1D84D74AD80E31D43A679B4C97360235073F5FF33A3CD2FD24A102CADE444EF825B4978CA6913343C9C20194BBB0D6F9D8DF90AF5AB2CD57A26D54A2982247F4'
+
+$packageArgs = @{
+  packageName    = $Env:ChocolateyPackageName
+  unzipLocation  = $contentDir
+
+  url64          = $url64
+  checksum64     = $checksum64
+  checksumType64 = 'sha512'
+}
 
 $keep = @(
   'arpaname.exe',
@@ -17,20 +31,25 @@ $keep = @(
   'liblwres.dll',
   'libxml2.dll',
   'nslookup.exe',
-  'nsupdate.exe',
-  'readme1st.txt'
+  'nsupdate.exe'
 )
 
-Install-ChocolateyZipPackage `
-  -PackageName 'bind' `
-  -Url 'https://downloads.isc.org/isc/bind9/9.14.2/BIND9.14.2.x86.zip' `
-  -Checksum 'B298210F80BE2E4813DE916202213393AB57C272BF25B7CB1392AC22E5DA4D97' `
-  -ChecksumType 'SHA256' `
-  -Url64 'https://downloads.isc.org/isc/bind9/9.14.2/BIND9.14.2.x64.zip' `
-  -Checksum64 'E49C525D16DB0348F5580E13D480323F24AC4FF39C93992D115393AFEC8486E1' `
-  -ChecksumType64 'SHA256' `
-  -UnzipLocation $content `
+$keepExtensions = @(
+  '.md',
+  ''
+)
 
-Get-ChildItem $content `
-  | ?{ $keep -notcontains $_ } `
+Install-ChocolateyZipPackage @packageArgs
+Get-ChildItem $contentDir `
+  | Where-Object {
+    if ($keep -contains $_) {
+      return $false
+    }
+
+    if ($keepExtensions -contains $_.Extension) {
+      return $false
+    }
+
+    return $true
+  } `
   | Remove-Item -Force -Recurse


### PR DESCRIPTION
This upgrades `bind‑toolsonly` to **v9.16.8**, which is the latest stable release.

---

I also recommend using @majkinetor’s [Automatic Updater](https://github.com/majkinetor/au) to automatically keep all packages in this repository up to date.