### PR TITLE
StigViewer2.14

### DIFF
--- a/packages/stigviewer/stigviewer.nuspec
+++ b/packages/stigviewer/stigviewer.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>stigviewer</id>
-    <version>2.13</version>
+    <version>2.14</version>
     <packageSourceUrl>https://github.com/AnthonyMastrean/chocolateypackages/tree/master/packages/stigviewer</packageSourceUrl>
     <owners>Anthony Mastrean</owners>
     <title>STIG Viewer</title>
@@ -10,7 +10,7 @@
     <projectUrl>https://public.cyber.mil/stigs/srg-stig-tools/</projectUrl>
     <!--<iconUrl>http://cdn.rawgit.com/__REPLACE_YOUR_REPO__/master/icons/example.png</iconUrl>-->
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <docsUrl>https://dl.dod.cyber.mil/wp-content/uploads/stigs/pdf/U_STIG_Viewer_2-x_User_Guide_V1R9.pdf</docsUrl>
+    <docsUrl>https://dl.dod.cyber.mil/wp-content/uploads/stigs/pdf/U_STIG_Viewer_2-x_User_Guide_V1R10.pdf</docsUrl>
     <tags>security defense harden</tags>
     <summary>Getting to the content of a XCCDF formatted STIG to read and understand the content is not as easy as opening a .doc or .pdf file and reading it. This is a tool which can be used to view the STIGs</summary>
     <description>

--- a/packages/stigviewer/stigviewer.nuspec
+++ b/packages/stigviewer/stigviewer.nuspec
@@ -14,29 +14,32 @@
     <tags>security defense harden</tags>
     <summary>Getting to the content of a XCCDF formatted STIG to read and understand the content is not as easy as opening a .doc or .pdf file and reading it. This is a tool which can be used to view the STIGs</summary>
     <description>
-The DoD/DISA STIG Viewer tool provides the capability to view one or more XCCDF.xml formatted STIGs in an easy to navigate human readable format. It is compatible with STIGs developed and published by DISA for the DoD.   The purpose of the STIG Viewer is to provide an intuitive graphical user interface that allows ease of access to the STIG content along with additional search and sort functionality unavailable with the current method of viewing the STIGs using a style sheet in a web browser.  STIG Viewer also supports additional functionality.
+The DoD/DISA STIG Viewer tool provides the capability to view one or more XCCDF (Extensible Configuration Checklist Description Format) formatted STIGs in an easy-to navigate, human-readable format. It is compatible with STIGs developed and published by DISA for the DoD. The purpose of the STIG Viewer is to provide an intuitive graphical user interface that allows ease of access to the STIG content, along with additional search and sort functionality unavailable with the current method of viewing the STIGs (using a style sheet in a web browser). 
 
-STIG Viewer features:
+STIG Viewer also supports additional functionality using the following features:
 
-* Multiple STIG files can be open in STIG Viewer at any given time.
-* One or more XCCDF STIG files can be individually loaded. 
-* XCCDF STIG files can be extracted from zipped STIG packages.
-* A 'Local Save-point' can be created on a system to store user configuration data and the current set of imported STIGs. This permits the last set of loaded STIGs to be reloaded each time the Viewer is started. The 'Local Save-point' can be deleted from the Viewer's options menu. Only one 'Local Save-point' can be created at a time.
-* Multiple XCCDF STIG files can be simultaneously unzipped and loaded from a .zip file containing one or more folders which contain the zipped STIG packages. STIG Viewer will drill down to find all XCCDF files and load them. A 'Local Save-point' is required for this operation as all XCCDF files are extracted to its local folder.
-* The list of STIG requirements/vulnerabilities can be sorted by STIG ID, Vulnerability ID, or Rule ID
-* All loaded STIG files can be searched or filtered based on one or more keywords.  All fields or individual fields can be searched. A filtered list of STIG requirements/vulnerabilities is returned
-* CCI data can be displayed if the CCI reference is contained in the STIG requirements/vulnerabilities
-* Loaded and filtered STIG data can be printed or exported to HTML and RTF file formats for use with other programs (i.e. web browsers and Microsoft Word). The printed/exported data is based on the list of requirements displayed in the center pane of the viewer.  The output is formatted as a tables  containing each requirement. 
-* A manual review checklist can be generated from the currently loaded STIG (or STIGs) or a filtered list. The checklist is generated from all requirements showing in the center pane. This checklist can be used to manually enter review results and notes. The manual review checklist can be saved and reloaded 
-* The manual review checklist can be formatted as a short form paper checklist for recording review results. This format can be exported to a file or printed
-* Automated review SCAP XCCDF Results files can be imported into the checklist populating the checklist with the automated results. The manual portion of the review can be completed and added to the automated results.
-* The checklist can be exported in a format that can be imported into VMS. 
-
-NOTE: This feature does not work well if a checklist is generated from multiple STIGs. Special handling is required
+* Allows multiple STIGs to be imported and used when creating checklists. 
+* Individually loads one or more XCCDF STIG files.
+* Extracts XCCDF STIG files from zipped STIG packages.
+* Creates a Local Data Cache on a system to store user configuration data and the current set of imported STIGs. This permits the reloading of the last set of loaded STIGs each time the STIG Viewer starts.
+* Deletes the Local Data Cache from the Viewer’s options menu. STIG Viewer can only create one Local Data Cache at a time.
+* Multiple XCCDF STIG files can be simultaneously unzipped and loaded from a .zip file containing one or more folders with zipped STIG packages. STIG Viewer will drill down to find all XCCDF files and load them. It then extracts all XCCDF files to its local folder since a Local Data Cache is required for this operation.
+* Sorts the list of STIG requirements/vulnerabilities by Vulnerability ID, STIG ID, Rule ID, CCI, or Group/Rule Name.
+* Searches or filters all loaded STIG files based on one or more keywords. Searches all fields or individual fields and then returns a filtered list of STIG requirements/vulnerabilities.
+* Searches may also be restricted to Rule Title, STIG ID, Vulnerability ID, Rule ID, Severity, or CCI.
+* Displays CCI data if the CCI reference is contained in the STIG requirements.
+* Prints or exports (HTML and RTF file formats) selected STIG data for use with other programs (i.e., web browsers and Microsoft Word).
+* Bases the printed/exported data on the list of requirements displayed in the center pane of the viewer and formats the output as a table containing each requirement. 
+* Imports automated review SCAP (Security Content Automation Protocol) or XCCDF Results into the checklist, populating the checklist with the automated results. The manual portion of the review can be completed and added to the automated results.
+* Exports the checklist as a .CSV file.
+* NOTE: DISA initially developed STIG Viewer in Java and delivered it as a single JAR file for use with the Oracle Java 8 Java Runtime Environment (JRE). With changes in Java licensing and distribution accompanying the release of Java 11, DISA now provides a standalone STIG Viewer application in a ZIP file that does not require the Oracle JRE. This allows the application to run on 64-bit X86 systems running Windows, Linux, and macOS with minimal disruption to existing workflows. This limits the program to running at the permission level of the currently logged-in user.
+* STIG Viewer does not open or use any network connections.
+* Java creates Local Data Caches in the logged-in user’s local directory. This is a different location in each operating system.
+* Under Windows 10, this is in the following directory: %USERPROFILE%\AppData\Local\STIGV_AppData (When clearing the Local Data Cache, Java deletes the folder and the Local Data Cache simultaneously.)
+* The input to the STIG Viewer is XCCDF contained in an XML file. STIG viewer rejects other file types. STIG Viewer is optimized for XCCDF-formatted STIGs produced by DISA for DoD
     </description>
     <releaseNotes>https://dl.dod.cyber.mil/wp-content/uploads/stigs/pdf/U_STIG_Viewer_2-11_Change_Log.pdf</releaseNotes>
     <dependencies>
-      <dependency id="jre8" version="[8.0,)" />
       <dependency id="chocolatey-core.extension" version="[1.0,)" />
     </dependencies>
   </metadata>

--- a/packages/stigviewer/tools/chocolateyinstall.ps1
+++ b/packages/stigviewer/tools/chocolateyinstall.ps1
@@ -8,8 +8,8 @@ $shortcut = Join-Path ([System.Environment]::GetFolderPath($shortcutdir)) 'STIG 
 Install-ChocolateyZipPackage `
     -PackageName $env:ChocolateyPackageName `
     -UnzipLocation $content `
-    -Url 'https://dl.dod.cyber.mil/wp-content/uploads/stigs/zip/U_STIGViewer_2-13_Win64.zip' `
-    -Checksum '0F5B1A23BBAAAF68E50079DA366EDF50C30B68A8E0E427B19D8AABD55E5099D9' `
+    -Url 'https://dl.dod.cyber.mil/wp-content/uploads/stigs/zip/U_STIGViewer_2-14_Win64.zip' `
+    -Checksum '4D22B3B11533F67A4890D5D81536086180C0D42D8025709569C0036255BF1ABF' `
     -ChecksumType 'SHA256'
 
 Install-ChocolateyShortcut `


### PR DESCRIPTION
- Updated from 2.13 to 2.14. 
- Updated description with the content from the new user guide. 
- Removed dependency to JRE8 since the package now comes with a built-in engine (they removed contingency to JRE because of new licensing model from Oracle). That is, the 64-bit-version comes with that built-in engine. 
- The link to the change log is for 2.11 - that is not a mistake - there is no newer published change log. 

The Package is already published - thanks for making me a maintainer, Anthony. 