### PR TITLE
Update chocolateyInstall.ps1

### DIFF
--- a/packages/kindlegen/tools/chocolateyInstall.ps1
+++ b/packages/kindlegen/tools/chocolateyInstall.ps1
@@ -3,7 +3,7 @@ $content = Join-Path (Split-Path $tools) 'content'
 
 Install-ChocolateyZipPackage `
     -PackageName 'kindlegen' `
-    -Url 'http://kindlegen.s3.amazonaws.com/kindlegen_win32_v2_9.zip' `
+    -Url 'https://archive.org/download/kindlegen_win32_v2_9/kindlegen_win32_v2_9.zip' `
     -Checksum '70B8401736684A1C390D4A95BA918283FCB3A36405C9A9895732DEB50274540B' `
     -ChecksumType 'SHA256' `
     -UnzipLocation $content


### PR DESCRIPTION
Use the archived version since the tool was removed from its original page. Both have the same checksum (the version from Archive.org was uploaded by Amazon).