### PR TITLE
fix(shellcheck): rename is no longer required

### DIFF
--- a/packages/shellcheck/shellcheck.nuspec
+++ b/packages/shellcheck/shellcheck.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>shellcheck</id>
     <title>ShellCheck</title>
-    <version>0.8.0</version>
+    <version>0.8.0.1</version>
     <authors>Vidar Holen</authors>
     <owners>Anthony Mastrean, Patrick Wyatt</owners>
     <summary>ShellCheck is a GPLv3 tool that gives warnings and suggestions for bash/sh shell scripts.</summary>

--- a/packages/shellcheck/tools/chocolateyInstall.ps1
+++ b/packages/shellcheck/tools/chocolateyInstall.ps1
@@ -1,7 +1,5 @@
-﻿$tools = Split-Path $MyInvocation.MyCommand.Definition
+$tools = Split-Path $MyInvocation.MyCommand.Definition
 $content = Join-Path (Split-Path $tools) 'content'
-$original = Join-Path $content 'shellcheck-v0.8.0.exe'
-$target = Join-Path $content 'shellcheck.exe'
 
 Install-ChocolateyZipPackage `
     -PackageName 'shellcheck' `
@@ -9,5 +7,3 @@ Install-ChocolateyZipPackage `
     -Checksum 'cc5208d9f8799d792122204196fafb700801b4bae9bbb0a8f8a999f0a13cca1bfad440b96a3746740d85da55901e1d652592490bc196afc8bc0ebd0ae20b9aa1' `
     -ChecksumType 'SHA512' `
     -UnzipLocation $content
-
-Rename-Item -Path $original -NewName $target -Force | Out-Null


### PR DESCRIPTION
Can you please republish a fix package? Probably as `0.8.0.1` ? 